### PR TITLE
click_next_image 함수 타임슬립 1초 -> 3초로 변경

### DIFF
--- a/main.py
+++ b/main.py
@@ -168,7 +168,7 @@ class Instagram:
         while True:
             try:
                 self.browser.find_element(By.CSS_SELECTOR,'button._afxw').click()
-                time.sleep(1.0)
+                time.sleep(3.0)
 
                 # 이미지 다운로드
                 self.download_image()


### PR DESCRIPTION
크롤링 실행하다가 다음 사진이 있음에도 불구하고 하나씩 씹히더라구요.
그래서 타입슬립은 3초로 늘려봤는데 정상적으로 실행이 되는 것 같습니다